### PR TITLE
Better error messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ from botocore.exceptions import ClientError
 import dotenv
 import psycopg2
 import jwt
-import dockercloud
 import requests
 
 class Deployer(object):

--- a/main.py
+++ b/main.py
@@ -45,11 +45,14 @@ class Deployer(object):
     def _run(self, cmd):
         out = ''
         try:
-            out = subprocess.check_output(cmd.split(' '))
-        except subprocess.CalledProcessError:
-            out = 'Error: ' + out
-        print(out)
-        return out
+            output = subprocess.check_output(cmd.split(' '), stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as process_error:
+            all_output = filter(None, process_error.output.split('\n'))
+            for output in all_output:
+                if not 'Error:' in output:
+                    output = 'Error: ' + str(output.strip())
+        print(output)
+        return output
 
     def docker(self):
         '''Deploy app to docker'''


### PR DESCRIPTION
Instead of output in https://github.com/datahq/deploy/issues/46#issuecomment-364074990, we see:

```
(.venv) ➜  deploy (better-error-messages) ✗ python main.py docker
Error: Not authorized
No existing stack found. Creating ...
Error: Not authorized
```