### PR TITLE
initial support for kubernetes + filemanager chart

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -1,0 +1,42 @@
+# Datahq Kubernetes Environment
+
+
+## Using Minikube for local infrastructure development
+
+* Install Minikube according to the instructions in latest [release notes](https://github.com/kubernetes/minikube/releases)
+* Create the local minikube cluster
+  * `minikube start`
+* Verify you are connected to the cluster
+  * `kubectl get nodes`
+
+
+## Deployment
+
+Deployment is managed using [helm charts](https://helm.sh/)
+
+* [Install helm](https://docs.helm.sh/using_helm/#quickstart)
+* Initialize helm on the cluster (Might need to setup RBAC in some cases, refer to helm docs)
+  * `helm init --history-max 1 --upgrade --wait`
+* Verify that it works
+  * `helm ls`
+
+
+## Deploying charts
+
+For example, to deploy the filemanager chart
+
+```
+helm upgrade filemanager ./charts/filemanager/ -if ./minikube-values.yaml
+```
+
+Wait for rollout to complete
+
+```
+kubectl rollout status deployment/filemanager
+```
+
+Check the resources
+
+```
+kubectl get all
+```

--- a/charts/filemanager/Chart.yaml
+++ b/charts/filemanager/Chart.yaml
@@ -1,0 +1,1 @@
+name: filemanager

--- a/charts/filemanager/templates/filemanager.yaml
+++ b/charts/filemanager/templates/filemanager.yaml
@@ -1,0 +1,40 @@
+{{ if .Values.filemanager.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: filemanager
+spec:
+  ports:
+  - name: '8000'
+    port: 8000
+  selector:
+    app: filemanager
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: filemanager
+spec:
+  replicas: {{ .Values.filemanager.replicas }}
+  template:
+    metadata:
+      labels:
+        app: filemanager
+    spec:
+      containers:
+      - name: filemanager
+        image: {{ .Values.filemanager.image | default "datopian/filemanager:latest" | quote }}
+        ports:
+        - containerPort: 8000
+        resources: {{ .Values.filemanager.resources }}
+        env:
+        - name: DATABASE_URL
+        {{ if .Values.filemanager.dbSecretName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.filemanager.dbSecretName | quote }}
+              key: "RDS_URI"
+        {{ else }}
+          value: "postgresql://postgres:123456@db/postgres"
+        {{ end }}
+{{ end }}

--- a/minikube-values.yaml
+++ b/minikube-values.yaml
@@ -1,0 +1,7 @@
+filemanager:
+  enabled: true
+  replicas: 1
+  resources: >
+    {"requests": {"cpu": "100m", "memory": "200Mi"}, "limits": {"cpu": "300m", "memory": "400Mi"}}
+  #  kubectl create secret generic db --from-literal=RDS_URI=postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+  # dbSecretName: db


### PR DESCRIPTION
I though that you might be interested in migrating to Kubernetes, if you are affected by docker cloud service shutting down..

* Added a kubernetes setup, it works locally with minikube, see the documentation in [KUBERNETES.md](https://github.com/OriHoch/deploy/blob/support-for-kubernetes/KUBERNETES.md#datahq-kubernetes-environment)
* Added filemanager chart
* This setup is very basic, you can see an example of a more complex Kubernetes environment with continuous deployment and full usage of Kubernetes features [here](https://github.com/Midburn/midburn-k8s/blob/master/README.md)