### PR TITLE
[.env.template][xs]: Replaced staging with production in STAGE variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,7 +8,7 @@ PROJECT=datahub
 # base domain to which prefixes are added such as STAGE and specific services
 DOMAIN_BASE=datahub.io
 # stage e.g. testing, production
-STAGE=production
+STAGE=testing
 # FQDN
 DOMAIN=${STAGE}.${DOMAIN_BASE}
 # API DOMAIN

--- a/.env.template
+++ b/.env.template
@@ -7,8 +7,8 @@ JWT_TOKEN=
 PROJECT=datahub
 # base domain to which prefixes are added such as STAGE and specific services
 DOMAIN_BASE=datahub.io
-# stage e.g. testing, staging, production
-STAGE=staging
+# stage e.g. testing, production
+STAGE=production
 # FQDN
 DOMAIN=${STAGE}.${DOMAIN_BASE}
 # API DOMAIN


### PR DESCRIPTION
Created a pull request for changing STAGE variable from staging to production in .env.template. STAGE must be either testing or production in the .env file for the script to work it can not be staging.