### PR TITLE
Improvement/resource allocation

### DIFF
--- a/charts-external/auth/templates/deployment.yaml
+++ b/charts-external/auth/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: auth
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure auth won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/filemanager/templates/deployment.yaml
+++ b/charts-external/filemanager/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: filemanager
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure filemanager won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/frontend/templates/deployment.yaml
+++ b/charts-external/frontend/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: frontend
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure frontend won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/metastore/templates/deployment.yaml
+++ b/charts-external/metastore/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: metastore
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure metastore won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/nginx/templates/deployment.yaml
+++ b/charts-external/nginx/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: nginx
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure nginx won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/plans/templates/deployment.yaml
+++ b/charts-external/plans/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: plans
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure plans won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/rawstore/templates/deployment.yaml
+++ b/charts-external/rawstore/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: rawstore
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure rawstore won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/resolver/templates/deployment.yaml
+++ b/charts-external/resolver/templates/deployment.yaml
@@ -5,6 +5,19 @@ metadata:
   name: resolver
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure resolver won't be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - specstore
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/charts-external/specstore/templates/deployment.yaml
+++ b/charts-external/specstore/templates/deployment.yaml
@@ -5,6 +5,26 @@ metadata:
   name: specstore
 spec:
   replicas: 1
+  {{ if .Values.enableAntiAffinity }}
+  affinity:
+    # ensure no service will be on the same node as specstore
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - auth
+            - filemanager
+            - frontend
+            - metastore
+            - nginx
+            - plans
+            - rawstore
+            - resolver
+        topologyKey: "kubernetes.io/hostname"
+  {{ end }}
   template:
     metadata:
       labels:

--- a/environments/datahub-production/values.yaml
+++ b/environments/datahub-production/values.yaml
@@ -17,11 +17,14 @@ auth:
                                        # --from-literal= \
                                        # --from-literal=
   secretName: auth-production
+  enableAntiAffinity: true
 filemanager:
   # kubectl create secret generic filemanager-production --from-literal=DATABASE_URL=
   secretName: filemanager-production
+  enableAntiAffinity: true
 frontend:
   secretName: frontend-production
+  enableAntiAffinity: true
   # kubectl create secret generic frontend-production --from-literal=API_URL=
                                                       # --from-literal=BITSTORE_URL=
                                                       # --from-literal=SITE_URL=
@@ -30,6 +33,7 @@ metastore:
   # kubectl create secret generic metastore-production --from-literal=DATAHUB_ELASTICSEARCH_ADDRESS= \
   #                                          --from-literal=PRIVATE_KEY=
   secretName: metastore-production
+  enableAntiAffinity: true
 nginx:
   enableLoadBalancer: true
   # gcloud --project=datahub-k8s  compute addresses create datahub-nginx (region: 13)
@@ -45,6 +49,7 @@ plans:
   #                                     --from-literal=SESSION_SECRET_KEY= \
   #                                     --from-literal=VIRTUAL_HOST=
   secretName: plans-production
+  enableAntiAffinity: true
 rawstore:
   # kubectl create secret generic rawstore-production --from-literal=AUTH_SERVER= \
   #                                        --from-literal=DATABASE_URL= \
@@ -54,10 +59,12 @@ rawstore:
   #                                        --from-literal=STORAGE_PATH_PATTERN= \
   #                                        --from-literal=VIRTUAL_HOST=
   secretName: rawstore-production
+  enableAntiAffinity: true
 resolver:
   # kubectl create secret generic resolver-production --from-literal=AUTH_SERVER= \
   #                                        --from-literal=VIRTUAL_HOST=
   secretName: resolver-production
+  enableAntiAffinity: true
 specstore:
   # kubectl create secret generic specstore --from-literal=AUTH_SERVER= \
   #                                         --from-literal=DATABASE_URL= \
@@ -71,3 +78,4 @@ specstore:
   #                                         --from-literal=PKGSTORE_BUCKET= \
   #                                         --from-literal=VIRTUAL_HOST=
   secretName: specstore-production
+  enableAntiAffinity: true

--- a/values.yaml
+++ b/values.yaml
@@ -37,4 +37,4 @@ resolver:
 specstore:
   enabled: true
   resources: >
-    {"requests": {"cpu": "1.2", "memory": "1000Mi"}, "limits": {"memory": "2000Mi"}}
+    {"requests": {"cpu": "1.5", "memory": "3000Mi"}, "limits": {"cpu": "2.0", "memory": "5500Mi"}}


### PR DESCRIPTION
This PR make spec store to be deployed on a dedicated single node. All other services will split across other 2 nodes. PT is heavily based on the carts of https://github.com/OpenBudget/budgetkey-k8s/ Eg: https://github.com/OpenBudget/budgetkey-k8s/blob/master/charts-external/elasticsearch/templates/deployment.yaml#L10-L24

Also small commit to request max CPU and memory for spec store.

Refs https://github.com/datahq/pm/issues/197